### PR TITLE
Update convertkit-ruby.gemspec

### DIFF
--- a/convertkit-ruby.gemspec
+++ b/convertkit-ruby.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv", "~> 2.1"
 
   spec.add_runtime_dependency "faraday", ">= 0.9.2"
-  spec.add_runtime_dependency "faraday_middleware", "~> 0.10.0"
+  spec.add_runtime_dependency "faraday_middleware", ">= 0.13.0"
   spec.add_runtime_dependency "json", '>= 1.8.3'
 end


### PR DESCRIPTION
Ensure we can use a more recent version of faraday_middleware